### PR TITLE
add a new constructor for users who don't have a string representation

### DIFF
--- a/src/main/java/edu/washington/cs/knowitall/regex/RegularExpression.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/RegularExpression.java
@@ -34,6 +34,15 @@ public class RegularExpression<E> implements Predicate<List<E>> {
         this.auto = this.build(this.expressions);
     }
 
+    public static <E> RegularExpression<E> compile(List<Expression<E>> expressions) {
+        return new RegularExpression<E>(expressions);
+    }
+
+    private RegularExpression(List<Expression<E>> expressions) {
+        this.expressions = expressions;
+        this.auto = this.build(this.expressions);
+    }
+
     public static <E> RegularExpression<E> compile(String expression,
             Function<String, BaseExpression<E>> factory) {
         return new RegularExpression<E>(expression, factory);


### PR DESCRIPTION
Maybe I'm missing something, but this constructor seems useful for users who don't have a string representation of their expression. For example, I already have a List of objects that I can convert into a List of Expressions.
