### PR TITLE
Add efficiency check to determine if a pattern could possible match n tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,19 +54,19 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.9.2</version>
+      <version>2.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.specs2</groupId>
-      <artifactId>specs2_2.9.2</artifactId>
-      <version>1.10</version>
+      <artifactId>specs2_2.10</artifactId>
+      <version>2.2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_2.9.2</artifactId>
-      <version>1.9</version>
+      <artifactId>scalacheck_2.10</artifactId>
+      <version>1.10.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/edu/washington/cs/knowitall/openregex/Function.java
+++ b/src/main/java/edu/washington/cs/knowitall/openregex/Function.java
@@ -1,0 +1,5 @@
+package edu.washington.cs.knowitall.openregex;
+
+public interface Function<X, Y> {
+    public abstract Y apply(X input);
+}

--- a/src/main/java/edu/washington/cs/knowitall/openregex/Predicate.java
+++ b/src/main/java/edu/washington/cs/knowitall/openregex/Predicate.java
@@ -1,0 +1,5 @@
+package edu.washington.cs.knowitall.openregex;
+
+public interface Predicate<X> {
+    boolean apply(X input);
+}

--- a/src/main/java/edu/washington/cs/knowitall/regex/Expression.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/Expression.java
@@ -184,7 +184,7 @@ public interface Expression<E> extends Predicate<E> {
         @Override
         public int minMatchingLength() {
             int left = this.expr1.minMatchingLength();
-            int right = this.expr1.minMatchingLength();
+            int right = this.expr2.minMatchingLength();
             if (left < right)
               return left;
             else

--- a/src/main/java/edu/washington/cs/knowitall/regex/Expression.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/Expression.java
@@ -19,6 +19,8 @@ public interface Expression<E> extends Predicate<E> {
 
     public Automaton<E> build();
 
+    public int minMatchingLength();
+
     /**
      * Represents a matching group that is referred to by order number.
      *     {@code (<foo> <bar>+)}
@@ -83,6 +85,15 @@ public interface Expression<E> extends Predicate<E> {
             prev.connect(auto.end);
 
             return auto;
+        }
+
+        @Override
+        public int minMatchingLength() {
+            int len = 0;
+            for (Expression<E> expr : this.expressions) {
+                len += expr.minMatchingLength();
+            }
+            return len;
         }
     }
 
@@ -169,6 +180,16 @@ public interface Expression<E> extends Predicate<E> {
 
             return auto;
         }
+
+        @Override
+        public int minMatchingLength() {
+            int left = this.expr1.minMatchingLength();
+            int right = this.expr1.minMatchingLength();
+            if (left < right)
+              return left;
+            else
+              return right;
+        }
     }
 
     /**
@@ -216,6 +237,11 @@ public interface Expression<E> extends Predicate<E> {
 
             return auto;
         }
+
+        @Override
+        public int minMatchingLength() {
+            return 0;
+        }
     }
 
     /**
@@ -261,6 +287,11 @@ public interface Expression<E> extends Predicate<E> {
 
             return auto;
         }
+
+        @Override
+        public int minMatchingLength() {
+            return 1;
+        }
     }
 
     /**
@@ -304,6 +335,11 @@ public interface Expression<E> extends Predicate<E> {
             auto.start.connect(auto.end);
 
             return auto;
+        }
+
+        @Override
+        public int minMatchingLength() {
+            return 0;
         }
     }
 
@@ -384,6 +420,11 @@ public interface Expression<E> extends Predicate<E> {
 
             return auto;
         }
+
+        @Override
+        public int minMatchingLength() {
+            return this.minOccurrences;
+        }
     }
 
     /**
@@ -421,6 +462,11 @@ public interface Expression<E> extends Predicate<E> {
 
             return auto;
         }
+
+        @Override
+        public int minMatchingLength() {
+            return 1;
+        }
     }
 
     /**
@@ -448,6 +494,11 @@ public interface Expression<E> extends Predicate<E> {
             auto.start.connect(auto.end, this);
 
             return auto;
+        }
+
+        @Override
+        public int minMatchingLength() {
+            return 0;
         }
     }
 

--- a/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
@@ -54,24 +54,30 @@ public class FiniteAutomaton {
         }
 
         public Match.FinalMatch<E> lookingAt(List<E> tokens, int startIndex) {
-            List<E> sublist = tokens.subList(startIndex, tokens.size());
-
-            Step<E> path = this.evaluate(sublist, startIndex == 0);
-            if (path == null) {
+            if (tokens.size() - startIndex - this.minMatchingLength() < 0) {
+                // don't try if we can't possible match
                 return null;
             }
+            else {
+                List<E> sublist = tokens.subList(startIndex, tokens.size());
 
-            // build list of edges
-            List<AbstractEdge<E>> edges = new ArrayList<AbstractEdge<E>>();
-            while (path.state != this.start) {
-                edges.add(path.path);
-                path = path.prev;
+                Step<E> path = this.evaluate(sublist, startIndex == 0);
+                if (path == null) {
+                    return null;
+                }
+
+                // build list of edges
+                List<AbstractEdge<E>> edges = new ArrayList<AbstractEdge<E>>();
+                while (path.state != this.start) {
+                    edges.add(path.path);
+                    path = path.prev;
+                }
+
+                Match.IntermediateMatch<E> match = new Match.IntermediateMatch<E>();
+                buildMatch(sublist.iterator(), null, new AtomicInteger(startIndex), this.start,
+                           Lists.reverse(edges).iterator(), match);
+                return new Match.FinalMatch<E>(match);
             }
-
-            Match.IntermediateMatch<E> match = new Match.IntermediateMatch<E>();
-            buildMatch(sublist.iterator(), null, new AtomicInteger(startIndex), this.start,
-                       Lists.reverse(edges).iterator(), match);
-            return new Match.FinalMatch<E>(match);
         }
 
         /**

--- a/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
@@ -45,6 +45,10 @@ public class FiniteAutomaton {
             return this.evaluate(tokens, true) != null;
         }
 
+        public int minMatchingLength() {
+            return start.minMatchingLength();
+        }
+
         public Match.FinalMatch<E> lookingAt(List<E> tokens) {
             return lookingAt(tokens, 0);
         }
@@ -363,6 +367,10 @@ public class FiniteAutomaton {
     public static class StartState<E> extends TerminusState<E> {
         public StartState(Expression<E> expression) {
             super(expression);
+        }
+
+        public int minMatchingLength() {
+            return this.expression.minMatchingLength();
         }
     }
 

--- a/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/FiniteAutomaton.java
@@ -53,6 +53,9 @@ public class FiniteAutomaton {
             return lookingAt(tokens, 0);
         }
 
+        /**
+         * @return null if no match, otherwise a representation of the match
+         */
         public Match.FinalMatch<E> lookingAt(List<E> tokens, int startIndex) {
             if (tokens.size() - startIndex - this.minMatchingLength() < 0) {
                 // don't try if we can't possible match

--- a/src/main/java/edu/washington/cs/knowitall/regex/RegularExpression.java
+++ b/src/main/java/edu/washington/cs/knowitall/regex/RegularExpression.java
@@ -131,7 +131,7 @@ public class RegularExpression<E> implements Predicate<List<E>> {
      */
     public Match<E> find(List<E> tokens, int start) {
         Match<E> match;
-        for (int i = start; i < tokens.size(); i++) {
+        for (int i = start; i <= tokens.size() - auto.minMatchingLength(); i++) {
             match = this.lookingAt(tokens, i);
             if (match != null) {
                 return match;

--- a/src/test/scala/edu/washington/cs/knowitall/regex/RegularExpressionAssertionTest.scala
+++ b/src/test/scala/edu/washington/cs/knowitall/regex/RegularExpressionAssertionTest.scala
@@ -16,7 +16,7 @@ class RegularExpressionAssertionTest extends Specification {
   val regexBoth = RegularExpressions.word(regexTokens.mkString(" "))
 
   def evaluate(regex: RegularExpression[String], tokens: List[String], value: Boolean) =
-    (if (value) "" else "not ") + "be found in '" + tokens.mkString(" ") + "'" in {
+    (if (value) "" else "not ") + "be found in '" + tokens.mkString(" ") + "': " in {
       regex.apply(tokens) must beTrue.iff(value)
     }
 

--- a/src/test/scala/edu/washington/cs/knowitall/regex/RegularExpressionNamedGroupTest.scala
+++ b/src/test/scala/edu/washington/cs/knowitall/regex/RegularExpressionNamedGroupTest.scala
@@ -10,12 +10,16 @@ class RegularExpressionNamedGroupTest extends Specification {
   val regex = RegularExpressions.word("(<subject>: <I> | (?: <The> (<subjadj>: <crazy>)? <Mariners>)) <know> <all> <of> (<poss>: <her> | (?: <the> (<possadj>: <dirty>?) <King> <'s>)) <secrets>")
 
   regex.toString should {
-    "match" in {
-      regex.apply("I know all of her secrets".split(" ").toList) must beTrue
-      regex.apply("The Mariners know all of her secrets".split(" ").toList) must beTrue
-      regex.apply("The Mariners know all of the dirty King 's secrets".split(" ").toList) must beTrue
-      regex.apply("The Mariners know all of the King 's secrets".split(" ").toList) must beTrue
-      regex.apply("The crazy Mariners know all of the King 's secrets".split(" ").toList) must beTrue
+    val matches = List("I know all of her secrets",
+      "The Mariners know all of her secrets",
+      "The Mariners know all of the dirty King 's secrets",
+      "The Mariners know all of the King 's secrets",
+      "The crazy Mariners know all of the King 's secrets")
+
+    matches.foreach { m =>
+      "match against " + m in {
+        regex.apply(m.split(" ").toList) must beTrue
+      }
     }
 
     "yield the correct groups" in {


### PR DESCRIPTION
If the pattern couldn't possible match `n` tokens, abort without running the automaton.  This pull request adds a `minMatchingLength` method to the parts of the automaton so this check can be performed.  This addresses https://github.com/knowitall/openregex/issues/8.
